### PR TITLE
do permission check against registered entity, not random object id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
   <properties>
     <jdk.version>1.8</jdk.version>
 
-    <lombok.version>1.16.10</lombok.version>
+    <lombok.version>1.18.2</lombok.version>
     <findbugs.version>3.0.1u2</findbugs.version>
 
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>

--- a/score-client/src/main/java/bio/overture/score/client/command/MountCommand.java
+++ b/score-client/src/main/java/bio/overture/score/client/command/MountCommand.java
@@ -145,13 +145,17 @@ public class MountCommand extends RepositoryAccessCommand {
       terminal.printStatus(i++, "Indexing remote entities" + tip + ". Please wait");
       val entities = terminal.printWaiting(this::resolveEntities);
 
-      log.info("Indexing remove objects...");
+      log.info("Indexing remote objects...");
       terminal.printStatus(i++, "Indexing remote objects" + tip + ". Please wait");
       List<ObjectInfo> objects = terminal.printWaiting(this::resolveObjects);
       if (hasManifest()) {
         // Manifest is a filtered view y'all!
         objects = filterManifestObjects(objects);
       }
+
+      // Filter for objects that have no entities.
+      val entityIds = entities.stream().map(Entity::getId).collect(toSet());
+      objects = objects.stream().filter( o -> entityIds.contains(o.getId())).collect(toList());
 
       //
       // Check access

--- a/score-client/src/main/java/bio/overture/score/client/mount/MountStorageContext.java
+++ b/score-client/src/main/java/bio/overture/score/client/mount/MountStorageContext.java
@@ -141,12 +141,15 @@ public class MountStorageContext implements StorageContext {
     val entityIndex = uniqueIndex(entities, Entity::getId);
 
     val files = ImmutableList.<StorageFile> builder();
-    for (val object : objects) {
+    if (objects == null) {
+      return files.build();
+    }
+    objects.stream().filter(o -> {
+      val objectId = o.getId();
+      return entityIndex.get(objectId) != null;
+    }).forEach(object -> {
       val objectId = object.getId();
       val entity = entityIndex.get(objectId);
-      if (entity == null) {
-        continue;
-      }
 
       // Join entity to object
       files.add(
@@ -157,7 +160,7 @@ public class MountStorageContext implements StorageContext {
               .lastModified(object.getLastModified())
               .size(object.getSize())
               .build());
-    }
+    });
 
     return files.build();
   }

--- a/score-client/src/main/java/bio/overture/score/client/mount/MountStorageContext.java
+++ b/score-client/src/main/java/bio/overture/score/client/mount/MountStorageContext.java
@@ -85,7 +85,7 @@ public class MountStorageContext implements StorageContext {
     try {
       // TODO: Figure out why getFirst fails. All objects should exist! May need to filter out junk bucket paths on
       // server as this could be causing the failure.
-      val probe = getLast(objects);
+      val probe = getLast(entities);
       val probeUrl = downloadService.getUrl(probe.getId());
       probeUrl.openStream();
     } catch (IOException e) {


### PR DESCRIPTION
This fixes a potential 404 that can occur when there are unregistered objects in the object storage.

This also ensures no mounting of unregistered objects is attempted.

Also an issue with FUSE was discovered, we can no longer mount all of collaboratory to a single directory as the number of files appears too large for FUSE to handle. 