### PR TITLE
fix: Deadlock fix with song and score

### DIFF
--- a/score-server/src/main/java/bio/overture/score/server/controller/DownloadController.java
+++ b/score-server/src/main/java/bio/overture/score/server/controller/DownloadController.java
@@ -17,12 +17,13 @@
  */
 package bio.overture.score.server.controller;
 
-import javax.servlet.http.HttpServletRequest;
-
 import bio.overture.score.core.model.ObjectSpecification;
-import bio.overture.score.server.util.HttpServletRequests;
 import bio.overture.score.server.repository.DownloadService;
 import bio.overture.score.server.security.TokenHasher;
+import bio.overture.score.server.util.HttpServletRequests;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
@@ -39,9 +40,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import lombok.Setter;
-import lombok.val;
-import lombok.extern.slf4j.Slf4j;
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * A controller to expose RESTful API for download
@@ -76,6 +75,7 @@ public class DownloadController {
       @RequestParam(value = "offset", required = true) long offset,
       @RequestParam(value = "length", required = true) long length,
       @RequestParam(value = "external", defaultValue = "false") boolean external,
+      @RequestParam(value = "exclude-urls", defaultValue = "false") boolean excludeUrls,
       @RequestHeader(value = "User-Agent", defaultValue = "unknown") String userAgent,
       HttpServletRequest request) {
 
@@ -83,7 +83,7 @@ public class DownloadController {
 
     log.info("Requesting download of object id {} with access token {} (MD5) from {} and client version {}", objectId,
         identifier(accessToken), ipAddress, userAgent);
-    return downloadService.download(objectId, offset, length, external);
+    return downloadService.download(objectId, offset, length, external, excludeUrls);
   }
 
   protected String identifier(String accessToken) {

--- a/score-server/src/main/java/bio/overture/score/server/repository/DownloadService.java
+++ b/score-server/src/main/java/bio/overture/score/server/repository/DownloadService.java
@@ -21,7 +21,7 @@ import bio.overture.score.core.model.ObjectSpecification;
 
 public interface DownloadService {
 
-  ObjectSpecification download(String objectId, long offset, long length, boolean forExternalUse);
+  ObjectSpecification download(String objectId, long offset, long length, boolean forExternalUse, boolean excludeUrls);
 
   /**
    * Attempts to fetch a pre-defined object id (defined in application.yml) from the object repository. Used to confirm

--- a/score-server/src/main/java/bio/overture/score/server/repository/azure/AzureDownloadService.java
+++ b/score-server/src/main/java/bio/overture/score/server/repository/azure/AzureDownloadService.java
@@ -68,7 +68,7 @@ public class AzureDownloadService implements DownloadService {
   private String sentinelObjectId;
 
   @Override
-  public ObjectSpecification download(String objectId, long offset, long length, boolean forExternalUse) {
+  public ObjectSpecification download(String objectId, long offset, long length, boolean forExternalUse, boolean excludeUrls) {
     try {
       checkArgument(offset >= 0L);
 

--- a/score-server/src/test/java/bio/overture/score/server/repository/s3/S3DownloadServiceTest.java
+++ b/score-server/src/test/java/bio/overture/score/server/repository/s3/S3DownloadServiceTest.java
@@ -9,8 +9,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
+
 import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,11 +52,11 @@ public class S3DownloadServiceTest {
     }
 
     @Test
-    public void verify_if_download_unpublished_objectId_is_blocked() {
+    public void verify_if_download_is_blocked_with_unpublished_objectId() {
         when(mockService.getAnalysisStateForMetadata(metadataEntity)).thenReturn("UNPUBLISHED");
         when(mockService.getEntity(objectId)).thenReturn(metadataEntity);
 
-        val throwable = catchThrowable(() -> s3DownloadService.download(objectId, 0, -1, false));
+        val throwable = catchThrowable(() -> s3DownloadService.download(objectId, 0, -1, false, false));
         assertThat(throwable).isExactlyInstanceOf(NotRetryableException.class);
     }
 

--- a/score-server/src/test/java/bio/overture/score/server/service/download/ObjectDownloadServiceTest.java
+++ b/score-server/src/test/java/bio/overture/score/server/service/download/ObjectDownloadServiceTest.java
@@ -17,22 +17,19 @@
  */
 package bio.overture.score.server.service.download;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
-
-import java.net.URL;
-import java.util.regex.Pattern;
-
 import bio.overture.score.core.util.ObjectKeys;
+import bio.overture.score.core.util.SimplePartCalculator;
 import bio.overture.score.server.config.ServerConfig;
 import bio.overture.score.server.exception.IdNotFoundException;
-import bio.overture.score.core.util.SimplePartCalculator;
 import bio.overture.score.server.metadata.MetadataEntity;
 import bio.overture.score.server.metadata.MetadataService;
 import bio.overture.score.server.repository.s3.S3BucketNamingService;
 import bio.overture.score.server.repository.s3.S3DownloadService;
 import bio.overture.score.server.repository.s3.S3URLGenerator;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.google.common.base.Splitter;
+import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,11 +40,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.s3.AmazonS3;
-import com.google.common.base.Splitter;
+import java.net.URL;
+import java.util.regex.Pattern;
 
-import lombok.val;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 @ContextConfiguration(classes = ServerConfig.class)
@@ -114,7 +115,7 @@ public class ObjectDownloadServiceTest extends S3DownloadService {
     firstException.setStatusCode(HttpStatus.NOT_FOUND.value());
     when(s3Client.getObject(Mockito.any())).thenThrow(firstException, firstException); // stubs first two calls to
                                                                                        // s3Client.getObject()
-    service.download(objectId, 0, 1000, false);
+    service.download(objectId, 0, 1000, false, false);
   }
 
   @Test
@@ -148,7 +149,7 @@ public class ObjectDownloadServiceTest extends S3DownloadService {
     val sut = spy(service);
     doReturn(os).when(sut).getSpecification(objectId);
 
-    val objSpec = sut.download(objectId, 0, 104857600, false);
+    val objSpec = sut.download(objectId, 0, 104857600, false, false);
 
     val p = objSpec.getParts().get(0);
 
@@ -194,7 +195,7 @@ public class ObjectDownloadServiceTest extends S3DownloadService {
     val sut = spy(service);
     doReturn(os).when(sut).getSpecification(objectId);
 
-    val objSpec = sut.download(objectId, 0, 104857600, false);
+    val objSpec = sut.download(objectId, 0, 104857600, false, false);
 
     val p = objSpec.getParts().get(0);
 


### PR DESCRIPTION
When song tries to publish, it calls the download endpoint on score. Since the analysis is currently
UNPUBLISHED and score will only allow downloads for PUBLISHED files, therefore song cannot publish
because score only allows published files to be download. Fix was to add a new path param, that will
return object spec WITHOUT urls.

Test was not included, as it required stubbing out the entire universe.

related to #140 