### PR TITLE
Added configurable token name to support  /o/check_api_key for ego

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,8 @@ services:
       S3_ACCESSKEY: minio
       S3_SECRETKEY: minio123
       S3_SIGV4ENABLED: "true"
-      AUTH_SERVER_URL: http://ego-api:8080/o/check_token/
+      AUTH_SERVER_URL: http://ego-api:8080/o/check_api_key/
+      AUTH_SERVER_TOKENNAME: apiKey
       AUTH_SERVER_CLIENTID: score
       AUTH_SERVER_CLIENTSECRET: scoresecret
       AUTH_SERVER_UPLOADSCOPE: score.WRITE

--- a/score-server/src/main/java/bio/overture/score/server/config/SecurityConfig.java
+++ b/score-server/src/main/java/bio/overture/score/server/config/SecurityConfig.java
@@ -98,12 +98,14 @@ public class SecurityConfig extends ResourceServerConfigurerAdapter {
   @Bean
   public RemoteTokenServices remoteTokenServices(
       final @Value("${auth.server.url}") String checkTokenUrl,
+      final @Value("${auth.server.tokenName:token}") String tokenName,
       final @Value("${auth.server.clientId}") String clientId,
       final @Value("${auth.server.clientSecret}") String clientSecret) {
     val remoteTokenServices = new CachingRemoteTokenServices();
     remoteTokenServices.setCheckTokenEndpointUrl(checkTokenUrl);
     remoteTokenServices.setClientId(clientId);
     remoteTokenServices.setClientSecret(clientSecret);
+    remoteTokenServices.setTokenName(tokenName);
     remoteTokenServices.setAccessTokenConverter(accessTokenConverter());
 
     log.debug("using auth server: " + checkTokenUrl);

--- a/score-server/src/main/resources/application.yml
+++ b/score-server/src/main/resources/application.yml
@@ -175,6 +175,7 @@ spring.profiles: secure
 auth:
   server:
     url: https://localhost:8443/oauth/check_token
+    tokenNamme: token
     clientId: resource
     clientSecret: pass
     uploadScope: aws.upload


### PR DESCRIPTION
ran the integration test using /o/check_api_key with tokenname==apiKey, with the following command:

`make clean test-upload-and-download DEMO_MODE=1`
