### PR TITLE
Score-client JDK update from 11 to 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Maven builder
 ###############################
 # -alpine-slim image does not support --release flag
-FROM adoptopenjdk/openjdk17:jdk-17-jdk-alpine as builder
+FROM adoptopenjdk/openjdk11:jdk-11.0.6_10-alpine-slim as builder
 
 ENV SERVER_JAR_FILE    /score-server.jar
 ENV CLIENT_DIST_DIR    /score-client-dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Maven builder
 ###############################
 # -alpine-slim image does not support --release flag
-FROM adoptopenjdk/openjdk11:jdk-11.0.6_10-alpine-slim as builder
+FROM adoptopenjdk/openjdk17:jdk-17-jdk-alpine as builder
 
 ENV SERVER_JAR_FILE    /score-server.jar
 ENV CLIENT_DIST_DIR    /score-client-dist
@@ -36,7 +36,7 @@ RUN cd score-client/target \
 FROM ubuntu:18.04 as client
 
 ENV CLIENT_DIST_DIR    /score-client-dist
-ENV JDK_DOWNLOAD_URL https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz
+ENV JDK_DOWNLOAD_URL https://download.java.net/openjdk/jdk17/ri/openjdk-17+35_linux-x64_bin.tar.gz
 ENV SCORE_CLIENT_HOME /score-client
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$SCORE_CLIENT_HOME/bin
 ENV SCORE_USER score
@@ -51,20 +51,20 @@ RUN useradd $SCORE_USER  \
 # Copy client dist from previous docker build staget
 COPY --from=builder $CLIENT_DIST_DIR/ $SCORE_CLIENT_HOME
 
-# Install Open JDK 11, and remove unused things at runtime 
+# Install Open JDK 17, and remove unused things at runtime
 RUN mkdir /usr/lib/jvm \
 	&& cd /usr/lib/jvm \
-	&& wget $JDK_DOWNLOAD_URL -O openjdk11.tar.gz \
-	&& tar zxvf openjdk11.tar.gz \
-	&& rm -rf openjdk11.tar.gz \
-	&& echo 'PATH=$PATH:/usr/lib/jvm/jdk-11/bin' >> /etc/environment \
-	&& echo 'JAVA_HOME=/usr/lib/jvm/jdk-11' >> /etc/environment \
-	&& rm -rf /usr/lib/jvm/jdk-11/jmods \
-	&& rm -rf /usr/lib/jvm/jdk-11/lib/src.zip \
-	&& update-alternatives --install "/usr/bin/java" "java" "/usr/lib/jvm/jdk-11/bin/java" 0 \
-	&& update-alternatives --install "/usr/bin/javac" "javac" "/usr/lib/jvm/jdk-11/bin/javac" 0 \
-	&& update-alternatives --set java /usr/lib/jvm/jdk-11/bin/java \
-	&& update-alternatives --set javac /usr/lib/jvm/jdk-11/bin/javac \
+	&& wget $JDK_DOWNLOAD_URL -O openjdk17.tar.gz \
+    && tar zxvf openjdk17.tar.gz \
+    && rm -rf openjdk17.tar.gz \
+    && echo 'PATH=$PATH:/usr/lib/jvm/jdk-17/bin' >> /etc/environment \
+    && echo 'JAVA_HOME=/usr/lib/jvm/jdk-17' >> /etc/environment \
+    && rm -rf /usr/lib/jvm/jdk-17/jmods \
+    && rm -rf /usr/lib/jvm/jdk-17/lib/src.zip \
+    && update-alternatives --install "/usr/bin/java" "java" "/usr/lib/jvm/jdk-17/bin/java" 0 \
+    && update-alternatives --install "/usr/bin/javac" "javac" "/usr/lib/jvm/jdk-17/bin/javac" 0 \
+    && update-alternatives --set java /usr/lib/jvm/jdk-17/bin/java \
+    && update-alternatives --set javac /usr/lib/jvm/jdk-17/bin/javac \
 	&& update-alternatives --list java \
 	&& update-alternatives --list javac \
 	&& java -version \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN useradd $SCORE_USER  \
 # Copy client dist from previous docker build staget
 COPY --from=builder $CLIENT_DIST_DIR/ $SCORE_CLIENT_HOME
 
-# Install Open JDK 17, and remove unused things at runtime
+# Install Open JDK 17, and remove unused things at runtime 
 RUN mkdir /usr/lib/jvm \
 	&& cd /usr/lib/jvm \
 	&& wget $JDK_DOWNLOAD_URL -O openjdk17.tar.gz \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,7 @@
 FROM ubuntu:18.04 as client
 
 ENV CLIENT_DIST_DIR    /score-client-dist
-ENV JDK_DOWNLOAD_URL https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz
+ENV JDK_DOWNLOAD_URL https://download.java.net/openjdk/jdk17/ri/openjdk-17+35_linux-x64_bin.tar.gz
 ENV SCORE_CLIENT_HOME /score-client
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$SCORE_CLIENT_HOME/bin
 ENV SCORE_USER score
@@ -19,20 +19,20 @@ RUN useradd $SCORE_USER  \
 
 COPY score-client/target/score-client-*-dist.tar.gz  /score-client.tar.gz
 
-# Install Open JDK 11, and remove unused things at runtime 
+# Install Open JDK 17, and remove unused things at runtime
 RUN mkdir /usr/lib/jvm \
 	&& cd /usr/lib/jvm \
-	&& wget $JDK_DOWNLOAD_URL -O openjdk11.tar.gz \
-    && tar zxvf openjdk11.tar.gz \
-	&& rm -rf openjdk11.tar.gz \
-	&& echo 'PATH=$PATH:/usr/lib/jvm/jdk-11/bin' >> /etc/environment \
-	&& echo 'JAVA_HOME=/usr/lib/jvm/jdk-11' >> /etc/environment \
-	&& rm -rf /usr/lib/jvm/jdk-11/jmods \
-	&& rm -rf /usr/lib/jvm/jdk-11/lib/src.zip \
-	&& update-alternatives --install "/usr/bin/java" "java" "/usr/lib/jvm/jdk-11/bin/java" 0 \
-	&& update-alternatives --install "/usr/bin/javac" "javac" "/usr/lib/jvm/jdk-11/bin/javac" 0 \
-	&& update-alternatives --set java /usr/lib/jvm/jdk-11/bin/java \
-	&& update-alternatives --set javac /usr/lib/jvm/jdk-11/bin/javac \
+	&& wget $JDK_DOWNLOAD_URL -O openjdk17.tar.gz \
+    && tar zxvf openjdk17.tar.gz \
+    && rm -rf openjdk17.tar.gz \
+    && echo 'PATH=$PATH:/usr/lib/jvm/jdk-17/bin' >> /etc/environment \
+    && echo 'JAVA_HOME=/usr/lib/jvm/jdk-17' >> /etc/environment \
+    && rm -rf /usr/lib/jvm/jdk-17/jmods \
+    && rm -rf /usr/lib/jvm/jdk-17/lib/src.zip \
+    && update-alternatives --install "/usr/bin/java" "java" "/usr/lib/jvm/jdk-17/bin/java" 0 \
+    && update-alternatives --install "/usr/bin/javac" "javac" "/usr/lib/jvm/jdk-17/bin/javac" 0 \
+    && update-alternatives --set java /usr/lib/jvm/jdk-17/bin/java \
+    && update-alternatives --set javac /usr/lib/jvm/jdk-17/bin/javac \
 	&& update-alternatives --list java \
 	&& update-alternatives --list javac \
 	&& java -version

--- a/score-client/src/main/java/bio/overture/score/client/command/DownloadCommand.java
+++ b/score-client/src/main/java/bio/overture/score/client/command/DownloadCommand.java
@@ -364,8 +364,8 @@ public class DownloadCommand extends RepositoryAccessCommand {
     checkParameter(
       Stream.of(!objectId.isEmpty(), manifestResource != null,analysisId != null && programId != null).
       filter(i -> i == Boolean.TRUE).count() == 1,
-      "Only one of --object-id, --manifest, or --analysisId may be specified. "
-        + "--studyId may only be used together with --analysisId, and is required if analysisId is specified.");
+      "Only one of --object-id, --manifest, or --analysis-id may be specified. "
+        + "--study-id may only be used together with --analysis-id, and is required if analysis-id is specified.");
   }
 }
 


### PR DESCRIPTION
Changes for score-client JDK update from 11 to 17, changing analysisId to analysis-id and studyId to study-id for the parameters-validation error message to avoid confusion. Ticket - #333