### PR TITLE
Jenkins timeout change

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 60, unit: 'MINUTES')
         timestamps()
     }
 


### PR DESCRIPTION
Increasing the timeout for jenkins build to 60 minutes from 30 minutes as https://github.com/overture-stack/score/commit/09cb8e43b13e9d6737198c33f20baaf859119c8d was failing due to a timeout.