### PR TITLE
Allow `--reference-file` to use compressed BGZIP files#347

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,6 +111,7 @@ pipeline {
                     branch 'develop'
                     branch 'master'
                     branch 'test*'
+                    branch 'test-header-only'
                 }
             }
             steps {
@@ -135,6 +136,7 @@ pipeline {
                     branch 'develop'
                     branch 'master'
                     branch 'test*'
+                    branch 'test-header-only'
                 }
             }
             parallel {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,7 +111,6 @@ pipeline {
                     branch 'develop'
                     branch 'master'
                     branch 'test*'
-                    branch 'test-header-only'
                 }
             }
             steps {
@@ -136,7 +135,6 @@ pipeline {
                     branch 'develop'
                     branch 'master'
                     branch 'test*'
-                    branch 'test-header-only'
                 }
             }
             parallel {

--- a/score-client/pom.xml
+++ b/score-client/pom.xml
@@ -252,7 +252,7 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
 
     <!-- Versions - Genomics -->
     <!--  <htsjdk.version>1.138</htsjdk.version> -->
-    <htsjdk.version>2.1.0</htsjdk.version>
+    <htsjdk.version>2.16.0</htsjdk.version>
 
     <!-- Versions - FUSE -->
     <javafs.version>0.1.0</javafs.version>


### PR DESCRIPTION
Upgraded from htsjdk 2.1.0 to 2.16.0 to support compressed zip files.