### PR TITLE
fix docker dind TLS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,19 +30,26 @@ spec:
     tty: true
     image: openjdk:11
     env:
-      - name: DOCKER_HOST
-        value: tcp://localhost:2375
+      - name: DOCKER_TLS_VERIFY
+        value: 1
+      - name: DOCKER_CERT_PATH
+        value: /var/lib/docker/tls/client
     volumeMounts:
+      - name: docker-graph-storage
+        mountPath: /var/lib/docker
       - name: maven-cache
         mountPath: "/root/.m2"
   - name: dind-daemon
     image: docker:20.10-dind
     securityContext:
-        privileged: true
-        runAsUser: 0
+      privileged: true
+      runAsUser: 0
     volumeMounts:
       - name: docker-graph-storage
         mountPath: /var/lib/docker
+    env:
+      - name: DOCKER_TLS_CERTDIR
+        value: /var/lib/docker/tls
   - name: helm
     image: alpine/helm:2.12.3
     command:
@@ -52,10 +59,15 @@ spec:
     image: docker:20-git
     tty: true
     env:
-    - name: DOCKER_HOST
-      value: tcp://localhost:2375
     - name: HOME
       value: /home/jenkins/agent
+    - name: DOCKER_TLS_VERIFY
+      value: 1
+    - name: DOCKER_CERT_PATH
+      value: /var/lib/docker/tls/client
+    volumeMounts:
+    - name: docker-graph-storage
+      mountPath: /var/lib/docker
   - name: curl
     image: curlimages/curl
     command:


### PR DESCRIPTION
This Docker dind version now requires to configure TLS env variables.
Ref: [link](https://hub.docker.com/_/docker#TLS:~:text=use%20this%20image-,TLS,-Starting%20in%2018.09)