### PR TITLE
Fix deprecated maven repo

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+      <groupId>fr.jcgay.maven</groupId>
+      <artifactId>maven-profiler</artifactId>
+      <version>3.2</version>
+    </extension>
+    <extension>
+        <groupId>com.github.gzm55.maven</groupId>
+        <artifactId>project-settings-extension</artifactId>
+        <version>0.1.1</version>
+    </extension>
+</extensions>

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,9 @@
+<settings>
+    <mirrors>
+        <mirror>
+            <id>conjars.org</id>
+            <url>https://conjars.wensel.net/repo/</url>
+            <mirrorOf>conjars.org</mirrorOf>
+        </mirror>
+    </mirrors>
+</settings>

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,5 +1,6 @@
 <settings>
     <mirrors>
+        <!-- This is a long term mirror repo as the original conjars.org repo is dead. Info:  https://conjars.wensel.net/  -->
         <mirror>
             <id>conjars.org</id>
             <url>https://conjars.wensel.net/repo/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
           </snapshots>
       </repository>
       <repository>
-          <id>conjars.org</id>
+          <id>conjars</id>
           <url>http://conjars.org/repo</url>
           <releases>
               <enabled>false</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
       </repository>
       <repository>
           <id>conjars.org</id>
-          <url>https://conjars.wensel.net/repo/</url>
+          <url>http://conjars.org/repo</url>
           <releases>
               <enabled>false</enabled>
           </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -71,17 +71,6 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
               <enabled>true</enabled>
           </snapshots>
       </repository>
-      <repository>
-          <id>conjars</id>
-          <url>http://conjars.org/repo</url>
-          <releases>
-              <enabled>false</enabled>
-          </releases>
-          <snapshots>
-              <enabled>false</enabled>
-          </snapshots>
-      </repository>
-
   </repositories>
 
   <dependencies>

--- a/score-test/pom.xml
+++ b/score-test/pom.xml
@@ -30,6 +30,19 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
   <name>${project.artifactId}</name>
   <description>${project.name}</description>
 
+    <repositories>
+        <repository>
+            <id>conjars.org</id>
+            <url>http://conjars.org/repo</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
   <dependencies>
 
     <!-- Test - S3 --> <!-- Note: needs to be first -->

--- a/score-test/pom.xml
+++ b/score-test/pom.xml
@@ -30,19 +30,6 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
   <name>${project.artifactId}</name>
   <description>${project.name}</description>
 
-    <repositories>
-        <repository>
-            <id>conjars.org</id>
-            <url>http://conjars.org/repo</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
   <dependencies>
 
     <!-- Test - S3 --> <!-- Note: needs to be first -->


### PR DESCRIPTION
**Description of the Issue:** 
The conjard.org repo url is dead.

**Solution:** 
Adding a mirror of conjars.org repo. 