### PR TITLE
S3 Service using API instead of .meta file

### DIFF
--- a/score-server/src/main/java/bio/overture/score/server/repository/s3/S3DownloadService.java
+++ b/score-server/src/main/java/bio/overture/score/server/repository/s3/S3DownloadService.java
@@ -37,6 +37,7 @@ import bio.overture.score.server.repository.URLGenerator;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -103,27 +104,29 @@ public class S3DownloadService implements DownloadService {
       val objectSpec = getSpecification(objectId);
 
       // Short-circuit in default case
-      if (!forExternalUse && (offset == 0L && length < 0L)) {
-        return excludeUrls ? removeUrls(objectSpec) : objectSpec;
-      }
+      if (objectSpec != null) {
+        if (!forExternalUse && (offset == 0L && length < 0L)) {
+          return excludeUrls ? removeUrls(objectSpec) : objectSpec;
+        }
 
-      // Calculate range values
-      // To retrieve to the end of the file
-      if (!forExternalUse && (length < 0L)) {
-        length = objectSpec.getObjectSize() - offset;
-      }
+        // Calculate range values
+        // To retrieve to the end of the file
+        if (!forExternalUse && (length < 0L)) {
+          length = objectSpec.getObjectSize() - offset;
+        }
 
-      // Validate offset and length parameters:
-      // Check if the offset + length > length - that would be too big
-      if ((offset + length) > objectSpec.getObjectSize()) {
-        throw new InternalUnrecoverableError(
-            "Specified parameters exceed object size (object id: "
-                + objectId
-                + ", offset: "
-                + offset
-                + ", length: "
-                + length
-                + ")");
+        // Validate offset and length parameters:
+        // Check if the offset + length > length - that would be too big
+        if ((offset + length) > objectSpec.getObjectSize()) {
+          throw new InternalUnrecoverableError(
+              "Specified parameters exceed object size (object id: "
+                  + objectId
+                  + ", offset: "
+                  + offset
+                  + ", length: "
+                  + length
+                  + ")");
+        }
       }
 
       // Construct ObjectSpecification for actual object in /data logical folder
@@ -136,21 +139,31 @@ public class S3DownloadService implements DownloadService {
       } else {
         parts = partCalculator.divide(offset, length);
       }
+      if (objectSpec != null) {
+        fillPartUrls(objectKey, parts, objectSpec.isRelocated(), forExternalUse);
 
-      fillPartUrls(objectKey, parts, objectSpec.isRelocated(), forExternalUse);
+        val spec =
+            new ObjectSpecification(
+                objectKey.getKey(),
+                objectId,
+                objectId,
+                parts,
+                length,
+                objectSpec.getObjectMd5(),
+                objectSpec.isRelocated());
 
-      val spec =
-          new ObjectSpecification(
-              objectKey.getKey(),
-              objectId,
-              objectId,
-              parts,
-              length,
-              objectSpec.getObjectMd5(),
-              objectSpec.isRelocated());
+        return excludeUrls ? removeUrls(spec) : spec;
+      } else {
+        ObjectMetadata metadata =
+            s3Client.getObjectMetadata(
+                bucketNamingService.getStateBucketName(objectId), objectKey.getKey());
+        fillPartUrls(objectKey, parts, false, forExternalUse);
+        val spec =
+            new ObjectSpecification(
+                objectKey.getKey(), objectId, objectId, parts, length, metadata.getETag(), false);
 
-      return excludeUrls ? removeUrls(spec) : spec;
-
+        return excludeUrls ? removeUrls(spec) : spec;
+      }
     } catch (Exception e) {
       log.error(
           "Failed to download objectId: {}, offset: {}, length: {}, forExternalUse: {}, excludeUrls: {} : {} ",
@@ -225,6 +238,8 @@ public class S3DownloadService implements DownloadService {
           objectKey,
           e);
       throw new NotRetryableException(e);
+    } catch (IdNotFoundException e) {
+      return null;
     }
   }
 

--- a/score-server/src/main/java/bio/overture/score/server/repository/s3/S3DownloadService.java
+++ b/score-server/src/main/java/bio/overture/score/server/repository/s3/S3DownloadService.java
@@ -119,11 +119,10 @@ public class S3DownloadService implements DownloadService {
         fillPartUrls(objectKey, parts, false, forExternalUse);
         objectSpec =
             new ObjectSpecification(
-                objectKey.getKey(), objectId, objectId, parts, length, metadata.getETag(), false);
+                objectKey.getKey(), objectId, objectId, parts, metadata.getContentLength(), metadata.getETag(), false);
       }
 
       // Short-circuit in default case
-      if (objectSpec != null) {
         if (!forExternalUse && (offset == 0L && length < 0L)) {
           return excludeUrls ? removeUrls(objectSpec) : objectSpec;
         }
@@ -146,8 +145,6 @@ public class S3DownloadService implements DownloadService {
                   + length
                   + ")");
         }
-      }
-      if (objectSpec != null) {
         fillPartUrls(objectKey, parts, objectSpec.isRelocated(), forExternalUse);
 
         val spec =
@@ -160,8 +157,7 @@ public class S3DownloadService implements DownloadService {
                 objectSpec.getObjectMd5(),
                 objectSpec.isRelocated());
 
-        return excludeUrls ? removeUrls(spec) : spec;
-      }
+      return excludeUrls ? removeUrls(spec) : spec;
     } catch (Exception e) {
       log.error(
           "Failed to download objectId: {}, offset: {}, length: {}, forExternalUse: {}, excludeUrls: {} : {} ",
@@ -174,7 +170,6 @@ public class S3DownloadService implements DownloadService {
 
       throw e;
     }
-    return null;
   }
 
   private static ObjectSpecification removeUrls(ObjectSpecification spec) {

--- a/score-server/src/test/java/bio/overture/score/server/service/download/ObjectDownloadServiceTest.java
+++ b/score-server/src/test/java/bio/overture/score/server/service/download/ObjectDownloadServiceTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.when;
 import bio.overture.score.core.util.ObjectKeys;
 import bio.overture.score.core.util.SimplePartCalculator;
 import bio.overture.score.server.config.ServerConfig;
-import bio.overture.score.server.exception.IdNotFoundException;
 import bio.overture.score.server.metadata.MetadataEntity;
 import bio.overture.score.server.metadata.MetadataService;
 import bio.overture.score.server.repository.s3.S3BucketNamingService;
@@ -104,7 +103,7 @@ public class ObjectDownloadServiceTest extends S3DownloadService {
     when(mockService.getEntity(objectId)).thenReturn(metadataEntity);
   }
 
-  @Test(expected = IdNotFoundException.class)
+  @Test(expected = NullPointerException.class)
   public void it_takes_two_to_fail_with_not_found() {
     // stubbing appears before the actual execution
     val firstException = new AmazonServiceException("Didn't find Object Id in bucket");


### PR DESCRIPTION
This commit refactors the **S3DownloadService** to utilize the S3 API directly instead of relying on a separate .meta file for object information. 

These changes improve the resilience of the S3 download service by-

- Preventing unexpected service failures due to null values or missing .meta files.
- Ensuring consistent execution flow by handling different scenarios uniformly.
- Null Handling: The code now checks if objectSpec is null and handles the case, preventing potential issues encountered earlier. 
- The code is responsible for using the part size (length) from the S3 API. By fetching object metadata and using it to fill part URLs and create the **ObjectSpecification**, the code ensures that the sizes and offsets match the actual stored parts on S3, rather than solely relying on user-specified values
- Exception Handling: The exception thrown when the .meta file was missing previously caused service failure. This is now caught and handled by returning null instead.
- Introduced a try-catch block to handle the IdNotFoundException that occurs when the .meta file is missing. By catching this exception and returning null, the service avoids failure and provides a controlled response, enhancing the overall stability of the application.

Additions to Unit Test Updates in order to validate the new exception handling mechanism. This test case ensures that the service does not fail when the .meta file is missing and that a **NullPointerException** is appropriately handled.

Overall, this commit modernizes the S3 service by leveraging the S3 API directly.