### PR TITLE
Refactor S3 Bucket Name Retrieval Method

### DIFF
--- a/score-server/src/main/java/bio/overture/score/server/repository/s3/S3DownloadService.java
+++ b/score-server/src/main/java/bio/overture/score/server/repository/s3/S3DownloadService.java
@@ -115,7 +115,7 @@ public class S3DownloadService implements DownloadService {
       if (objectSpec == null) {
         ObjectMetadata metadata =
             s3Client.getObjectMetadata(
-                bucketNamingService.getStateBucketName(objectId), objectKey.getKey());
+                bucketNamingService.getObjectBucketName(objectId), objectKey.getKey());
         fillPartUrls(objectKey, parts, false, forExternalUse);
         objectSpec =
             new ObjectSpecification(


### PR DESCRIPTION
The code has been refactored to use a different method for retrieving the S3 bucket name. Previously, the method **getStateBucketName** was used to obtain the bucket name, but it has been replaced with **getObjectBucketName**. This change ensures that the correct bucket name is used when fetching the object metadata from the S3 client