### PR TITLE
Retrieve MD5 from object metadata

### DIFF
--- a/score-server/src/main/java/bio/overture/score/server/config/S3Config.java
+++ b/score-server/src/main/java/bio/overture/score/server/config/S3Config.java
@@ -39,6 +39,9 @@ public class S3Config {
   private boolean sigV4Enabled;
   private String masterEncryptionKeyId;
 
+  @Value("md5chksum")
+  private String customMd5Property;
+
   @Value("${upload.connection.timeout}")
   private int connectionTimeout;
 

--- a/score-server/src/main/java/bio/overture/score/server/repository/s3/S3DownloadService.java
+++ b/score-server/src/main/java/bio/overture/score/server/repository/s3/S3DownloadService.java
@@ -212,7 +212,7 @@ public class S3DownloadService implements DownloadService {
   private String getObjectMd5(ObjectMetadata metadata) {
     val contentMd5 = metadata.getContentMD5();
     if (contentMd5 != null) {
-      return contentMd5;
+      return  MD5s.toHex(contentMd5);
     }
     val userMetadataMd5 =
         metadata.getUserMetaDataOf(s3config.getCustomMd5Property()); // get literal from config

--- a/score-server/src/main/resources/application.yml
+++ b/score-server/src/main/resources/application.yml
@@ -34,6 +34,9 @@ s3:
   secured: true
   sigV4Enabled: true
 
+  # custom meta property with md5 hash, unused when upload state files are available (default behaviour)
+  # customMd5Property: md5chksum
+
   #amazon
   endpoint: s3-external-1.amazonaws.com
 


### PR DESCRIPTION
For S3 downloads, when handling downloads in cases where the `.meta` file is not found, we need to retrieve the MD5 sum from the Object metadata. Our current implementation of this is reading the value of the eTag, but this is not guaranteed to contain an MD5 hash (and for multipart uploads is known to never contain the MD5 hash).

This change introduces a function to get the MD5 hash from the metadata. The function has two cases to check for where the MD5 hash might be.
1. Priority is to use the built in S3 getContentMD5() method. If the hash is found here then this will be returned. 
2. Allow reading of a custom (user defined) metadata property. This allows a system administrator to assign the Base64 encoded MD5 hash in a custom location. This is given the default property name `md5chksum` which corresponds to the property name where the md5 is stored in Azure systems. This will match for cases where data is moved from Azure Blob storage into an S3 Object Storage system.